### PR TITLE
Return self in fit method

### DIFF
--- a/pygtm/gtm.py
+++ b/pygtm/gtm.py
@@ -74,6 +74,7 @@ class GTM(BaseEstimator, TransformerMixin):
                 if self.verbose:
                     print('converged.')
                 break
+        return self
     
     def transform(self, X, y=None):
         assert self.method in ('mean', 'mode')


### PR DESCRIPTION
This fixes a problem when calling `fit_transform` on the `GTM` class. 

GTM inherits the `fit_transform` method from `TransformerMixin`. Under the hood, this method calls
`self.fit(...).transform(...)`. If `fit` does not return something, then we get an error.

Btw.: nice implementation of GTM. :)